### PR TITLE
feat: Sprint 2 — memory-prune routing, combined /code-quality command

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "code-quality",
-  "version": "1.1.0",
-  "description": "Claude Code plugin for code auditing (security, cost, performance, cleanup), config refinement, memory cleanup, and jCodeMunch project indexing.",
+  "version": "1.2.0",
+  "description": "Claude Code plugin for code auditing (security, cost, performance, cleanup), config refinement, memory cleanup, jCodeMunch indexing, and combined quality workflows.",
   "author": {
     "name": "Musab Kara",
     "url": "https://github.com/SkyWalker2506"
@@ -29,6 +29,11 @@
       "name": "memory-prune",
       "description": "Scan ~/.claude/projects/ memory files and clean stale/duplicate entries.",
       "argument-hint": "[--dry-run|--auto]"
+    },
+    {
+      "name": "code-quality",
+      "description": "Combined workflow — index + audit + optional refine. Single unified report.",
+      "argument-hint": "[--no-index|--refine|--no-refine]"
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -58,6 +58,15 @@ Scan Claude memory files under `~/.claude/projects/` and clean up stale, duplica
 - Empty/trivial content (<3 meaningful lines)
 - Superseded decisions (newer feedback explicitly reverses it)
 
+### `/code-quality` — Combined Workflow
+Run the full quality pipeline in one command: index with jCodeMunch, audit all categories, and optionally refine config.
+
+```
+/code-quality              # Index + full audit
+/code-quality --refine     # Index + audit + refine project config
+/code-quality --no-index   # Audit only (skip indexing)
+```
+
 ## MCP Dependencies
 
 - **jcodemunch** — Required for `/index`, enhances `/audit` with symbol-aware scanning. Installed via `uvx jcodemunch-mcp`.

--- a/commands/code-quality.md
+++ b/commands/code-quality.md
@@ -1,0 +1,170 @@
+---
+name: code-quality
+description: "Combined code quality workflow — index → audit → optional refine. Single unified report."
+argument-hint: "[--no-index|--no-refine|--refine]"
+---
+
+# /code-quality — Combined Quality Workflow
+
+Run the full code quality pipeline in a single command: index the project with jCodeMunch, scan for issues, and optionally refine config files. Produces a unified report.
+
+## Usage
+
+```
+/code-quality              → index + audit (all categories), no refine
+/code-quality --refine     → index + audit + refine current project config
+/code-quality --no-index   → skip indexing, audit only
+/code-quality --no-refine  → same as default (explicit)
+```
+
+## Arguments
+
+```
+$ARGUMENTS
+```
+
+Parse flags:
+- `--refine` → also run `/refine project` after audit
+- `--no-index` → skip jCodeMunch indexing step
+- `--no-refine` → skip refine (default behavior)
+
+## Execution
+
+Run sequentially — each step depends on the previous completing successfully.
+
+```python
+Agent(
+  prompt=<pipeline prompt below>,
+  model="sonnet",
+  run_in_background=True,
+  description="code-quality pipeline"
+)
+```
+
+### Agent Prompt
+
+```
+You are a code quality pipeline agent. Run the following steps in order.
+
+FLAGS: [parse from $ARGUMENTS]
+  - skip_index: --no-index present
+  - run_refine: --refine present
+
+PROJECT ROOT: current working directory
+
+---
+
+## STEP 1 — LANGUAGE DETECTION
+
+Detect primary language(s):
+- `pubspec.yaml` → Flutter/Dart
+- `package.json` → JavaScript/TypeScript
+- `requirements.txt` / `pyproject.toml` → Python
+- `go.mod` → Go
+- File extensions in src/lib/root as fallback
+
+Report:
+```
+Stack: [detected stack]
+```
+
+---
+
+## STEP 2 — INDEX (skip if --no-index)
+
+Check if jCodeMunch MCP is available. If yes:
+1. Call `resolve_repo(path=os.getcwd())`
+2. Call `index_folder(path=os.getcwd())` (incremental)
+3. Report: "jCodeMunch index: updated"
+
+If jCodeMunch not available:
+Report: "jCodeMunch index: skipped (MCP not connected)"
+
+---
+
+## STEP 3 — AUDIT
+
+Run a focused code quality scan. Use jCodeMunch symbol data if available from Step 2.
+
+Perform all 4 audit categories for the detected stack:
+
+### SECURITY
+- Hardcoded secrets (grep: apiKey, api_key, secret, password, token)
+- .env in .gitignore?
+- Stack-specific: see full /audit checklist per language
+
+### COST
+- Paid API calls without rate limiting
+- Large assets (>500KB)
+- Stack-specific cost risks
+
+### PERFORMANCE
+- Memory leaks, unreleased resources
+- Stack-specific performance issues
+
+### CLEANUP
+- Dead code, TODO/FIXME, unused imports
+- Missing .gitignore entries
+- Stack-specific hygiene
+
+Max 30 tool calls for audit. Be efficient — grep broadly, read to confirm.
+
+---
+
+## STEP 4 — REFINE (only if --refine)
+
+Scan config files in current project:
+- `CLAUDE.md`, `.claude/settings.json`, `.mcp.json`
+- Identify: duplication, conflicts, stale content, bloat
+
+Present a diff summary. Apply improvements.
+
+---
+
+## UNIFIED REPORT
+
+Output a single consolidated report:
+
+```
+# Code Quality Report — [project name]
+Date: [today]
+Stack: [detected]
+jCodeMunch: [updated | skipped]
+
+## Audit Findings
+
+[findings grouped by category]
+
+## Summary Table
+
+| # | Level | Category | File | Issue |
+|---|-------|----------|------|-------|
+
+## Overall Score: X/10
+
+## Refine Changes (if --refine)
+[list of config changes made]
+```
+
+Levels: RED CRITICAL / ORANGE HIGH / YELLOW MEDIUM / BLUE INFO
+
+---
+
+## RULES
+
+- Read-only for audit — do NOT edit source files
+- jCodeMunch failure is non-fatal — continue with audit
+- Max 40 tool calls total across all steps
+- Refine only touches config files (CLAUDE.md, settings.json, .mcp.json)
+```
+
+## Output
+
+Show the unified report when the agent completes. Highlight critical findings.
+
+## Constraints
+
+- Source code (lib/, src/, test/) is read-only
+- Refine only runs if `--refine` flag is present
+- jCodeMunch indexing failure is non-fatal
+- Max 40 tool calls total

--- a/skills/code-quality/SKILL.md
+++ b/skills/code-quality/SKILL.md
@@ -1,13 +1,15 @@
 ---
 name: code-quality
-description: "Auto-trigger skill for code quality auditing, config refinement, and jCodeMunch indexing."
+description: "Auto-trigger skill for code quality auditing, config refinement, memory cleanup, and jCodeMunch indexing."
 triggers:
   - "audit"
   - "code audit"
   - "security audit"
   - "cost audit"
   - "performance audit"
-  - "cleanup"
+  - "code cleanup"
+  - "clean up code"
+  - "cleanup dead code"
   - "dead code"
   - "refine"
   - "refine config"
@@ -16,24 +18,32 @@ triggers:
   - "jcodemunch"
   - "index project"
   - "code quality"
-  - "code review"
   - "scan for issues"
   - "find vulnerabilities"
   - "unused imports"
   - "unused dependencies"
+  - "memory prune"
+  - "prune memory"
+  - "clean memory files"
+  - "stale memory"
+  - "prune memory files"
+  - "claude memory cleanup"
+  - "memory cleanup"
 ---
 
 # Code Quality Skill
 
-This skill activates when the user mentions code auditing, config refinement, or project indexing. It routes to the appropriate command.
+This skill activates when the user mentions code auditing, config refinement, memory cleanup, or project indexing. It routes to the appropriate command.
 
 ## Routing
 
 | User Intent | Command |
 |-------------|---------|
-| Audit code, scan for issues, security check, find vulnerabilities, dead code, cleanup | `/audit` |
+| Audit code, scan for issues, security check, find vulnerabilities, dead code, code cleanup | `/audit` |
 | Refine CLAUDE.md, clean up config, tighten settings, fix duplication | `/refine` |
 | Index project, jCodeMunch, symbol search setup | `/index` |
+| Memory prune, clean memory files, stale memory, memory cleanup | `/memory-prune` |
+| Full code quality workflow, combined check | `/code-quality` |
 
 ## Behavior
 
@@ -51,9 +61,12 @@ This skill activates when the user mentions code auditing, config refinement, or
 | "Clean up all config files" | `/refine all` |
 | "Index this project" | `/index` |
 | "Set up jCodeMunch" | `/index` |
-| "Do a full code quality check" | `/audit all` |
+| "Do a full code quality check" | `/code-quality` |
+| "Clean up stale memory files" | `/memory-prune` |
+| "Prune memory" | `/memory-prune` |
+| "Remove old Claude memory entries" | `/memory-prune --auto` |
 
 ## Dependencies
 
 - **jCodeMunch MCP** — required for `/index`, useful for `/audit` (symbol-aware scanning)
-- Commands are defined in `commands/audit.md`, `commands/refine.md`, `commands/index.md`
+- Commands are defined in `commands/audit.md`, `commands/refine.md`, `commands/index.md`, `commands/memory-prune.md`, `commands/code-quality.md`


### PR DESCRIPTION
## Summary

- **`/memory-prune` in SKILL.md routing**: Added 7 new triggers (memory prune, prune memory, clean memory files, stale memory, prune memory files, claude memory cleanup, memory cleanup). Added routing row to the table.
- **Removed ambiguous triggers**: Removed `"code review"` (too broad, conflicts with PR review) and bare `"cleanup"` (replaced with `"code cleanup"`, `"clean up code"`, `"cleanup dead code"`).
- **New `/code-quality` combined command**: `commands/code-quality.md` — runs index → audit → optional refine in a single pipeline with a unified report.
- **SKILL.md routing for `/code-quality`**: "full code quality check" and "combined check" now route to `/code-quality`.
- **`plugin.json` updated**: Added `/code-quality` command, bumped to v1.2.0.
- **README updated**: Added `/code-quality` section with usage examples.

## Issues Closed

- Closes #5 (/memory-prune routing)
- Closes #6 (/code-quality combined command)

## Test Plan

- [ ] "Clean up stale memory files" triggers `/memory-prune`
- [ ] "Prune memory" triggers `/memory-prune`
- [ ] "Do a full code quality check" triggers `/code-quality`
- [ ] `/code-quality` runs index then audit in sequence
- [ ] `/code-quality --refine` also runs refine step
- [ ] `/code-quality --no-index` skips index, audit still runs
- [ ] "code review" no longer triggers this skill